### PR TITLE
Fix NSInternalInconsistencyException issue

### DIFF
--- a/AVPlayer-SwiftUI/Utility.swift
+++ b/AVPlayer-SwiftUI/Utility.swift
@@ -19,6 +19,9 @@ class Utility: NSObject {
     }()
     
     static func formatSecondsToHMS(_ seconds: Double) -> String {
+        if seconds.isNaN {
+            return "00:00"
+        }
         return timeHMSFormatter.string(from: seconds) ?? "00:00"
     }
     


### PR DESCRIPTION
Fix issue of NSInternalInconsistencyException occurring at times, reason: 'Invalid parameter not satisfying: isfinite(timeInterval) && !isnan(timeInterval)'.